### PR TITLE
Update mac-key-press to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "sensortag": "~0.1.7",
     "debug": "~0.7.4",
-    "mac-key-press": "~0.1.0",
+    "mac-key-press": "~0.2.0",
     "yargs": "~1.2.1"
   },
   "keywords": [


### PR DESCRIPTION
mac-key-press v0.2.0 has support for node v0.12.0 and iojs